### PR TITLE
add unix socket support for prometheus

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -118,7 +118,7 @@ func serveOnUnixSocket(socketPath string) {
 
 func serveOnIpPort(ipPort string) {
 	if err := http.ListenAndServe(ipPort, nil); err != nil {
-		glog.Errorf("Error starting Prometheus at ip port %v: %v", ipPort, err)
+		glog.Errorf("Error starting Prometheus at IP port %v: %v", ipPort, err)
 		os.Exit(1)
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -96,7 +96,7 @@ func InitPrometheus(prometheusHost, prometheusPort, prometheusEntry string) {
 			serveOnUnixSocket(socketPath)
 		} else {
 			ipPort := prometheusHost+":"+prometheusPort
-			glog.Infof("Starting Prometheus on IP port %v:%v, entry point is /%v", ipPort, prometheusEntry)
+			glog.Infof("Starting Prometheus on IP port %v, entry point is /%v", ipPort, prometheusEntry)
 			serveOnIpPort(ipPort)
 		}
 		

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -93,7 +93,7 @@ func InitPrometheus(prometheusHost, prometheusPort, prometheusEntry string) {
 		if strings.HasPrefix(prometheusHost, "unix:") {
 			socketPath := prometheusHost[5:]
 			glog.Infof("Starting Prometheus on Unix socket %v, entry point is /%v", socketPath, prometheusEntry)
-			os.Remove(socketPath) // allow failure
+			_ := os.Remove(socketPath) // allow failure
 			unixListener, err := net.Listen("unix", socketPath)
 			if err != nil {
 				glog.Errorf("Error starting Prometheus on socket %v: %v", socketPath, err)


### PR DESCRIPTION
this PR allows for listening on a Unix domain socket for prometheus metrics by prefixing the path with `unix:`

also open to alternative prefixes like `unix/` (which is what caddy uses)

some of this approach can probably be reused for https://github.com/shizunge/endlessh-go/issues/112

example usage:

starting endlessh-go
```
./endlessh-go -alsologtostderr -enable_prometheus -prometheus_host unix:./coolmetricsocket.socket
```

try connecting to generate some metrics
```
ssh -v localhost -o Port=2222
```

get the metrics
```
curl -v --unix-socket ./coolmetricsocket.socket whateverhostnameyouwant/metrics
```