### PR TITLE
Make the country connections panel title case

### DIFF
--- a/dashboard/endlessh.json
+++ b/dashboard/endlessh.json
@@ -919,7 +919,7 @@
           "refId": "A"
         }
       ],
-      "title": "Connections by country",
+      "title": "Connections by Country",
       "transformations": [
         {
           "id": "filterByRefId",


### PR DESCRIPTION
The title for the connections by country panel in the dashboard isn't in title case, while all the other panels are.