### PR TITLE
Add PROXY protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Usage of ./endlessh-go
         The address for prometheus (default "0.0.0.0")
   -prometheus_port string
         The port for prometheus (default "2112")
+  -proxy_protocol_enabled
+        Enable PROXY protocol support. This causes the server to expect PROXY protocol headers on incoming connections.
+  -proxy_protocol_read_header_timeout_ms int
+        Timeout for reading the PROXY protocol header in milliseconds. If the connection does not send a valid PROXY protocol header in this time, the header is ignored. (default 200)
   -stderrthreshold value
         logs at or above this threshold go to stderr (default 2)
   -v value

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oschwald/maxminddb-golang v1.13.0 // indirect
+	github.com/pires/go-proxyproto v0.8.1 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/pierrre/go-libs v0.17.0 h1:bjxd9unioV/YDkUW7obETp2IFct0kO9HePURn81UL8
 github.com/pierrre/go-libs v0.17.0/go.mod h1:920odOqc5mZREW9GFWg056mjQ2prNVRGUZO7HRS2Jlc=
 github.com/pierrre/pretty v0.14.3 h1:I100hHs1C/MCd3M0D/hIV7J2OXl7amLD0uP2jnB7mRw=
 github.com/pierrre/pretty v0.14.3/go.mod h1:HTaFDNtT9ELVK5pODLfXRLiEiyIx3MmQUL5UadrR3/0=
+github.com/pires/go-proxyproto v0.8.1 h1:9KEixbdJfhrbtjpz/ZwCdWDD2Xem0NZ38qMYaASJgp0=
+github.com/pires/go-proxyproto v0.8.1/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=


### PR DESCRIPTION
Thanks for this wonderful tool!

I have been using the tarpit behind a load balancer with the PROXY protocol enabled. As advised in https://github.com/shizunge/endlessh-go/issues/145, using the proxy protocol wrapper is an easy way to add support for the PROXY protocol.

I have added two configuration options, one enables the proxy proto and the other sets a read header timeout.
If the proxy, for whatever reason does not send a PROXY protocol header, this timeout will ensure that the wrapper ignores the header and allows the tarpit to keep the visitor busy 😎.