### PR TITLE
Added healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD ["/endlessh", "-healthcheck"]
 USER nobody
 ENTRYPOINT  ["/endlessh"]
-CMD ["-logtostderr", "-v=1"]
+CMD ["-logtostderr", "-v=1", "-enable_healthcheck"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ LABEL org.opencontainers.image.licenses=GPLv3
 
 COPY --from=build /endlessh/endlessh /endlessh
 EXPOSE 2222 2112
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["/endlessh", "-healthcheck"]
 USER nobody
 ENTRYPOINT  ["/endlessh"]
 CMD ["-logtostderr", "-v=1"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Usage of ./endlessh-go
         Enable prometheus
   -geoip_supplier string
         Supplier to obtain Geohash of IPs. Possible values are "off", "ip-api", "max-mind-db" (default "off")
+  -healthcheck
+        GET healthcheck_host:healthcheck_port/health and exit 1 if status is not ok or timeout is exceeded (for container healthcheck)
+  -healthcheck_host string
+        The address for container healthcheck (default "127.0.0.1")
+  -healthcheck_port string
+        HTTP port for container healthcheck; serves JSON with status and uptime at /health (default "51000")
   -host string
         SSH listening address (default "0.0.0.0")
   -interval_ms int
@@ -120,6 +126,23 @@ It listens to port `2112` and entry point is `/metrics` by default. The port and
 The endlessh-go server stores the geohash of attackers as a label on `endlessh_client_open_count`, which is also off by default. You can turn it on via the CLI argument `-geoip_supplier`. The endlessh-go uses service from [ip-api](https://ip-api.com/), which may enforce a query rate and limit commercial use. Visit their website for their terms and policies.
 
 You could also use an offline GeoIP database from [MaxMind](https://www.maxmind.com) by setting `-geoip_supplier` to _max-mind-db_ and `-max_mind_db` to the path of the database file.
+
+## Healthcheck
+
+The endlessh-go server exposes an HTTP health endpoint while the server is running. By default it listens on `127.0.0.1:51000` at `/health` and returns a JSON like this:
+
+```json
+{
+      "status": "ok",
+      "uptime": 123.456789012
+}
+```
+
+`status` is always "ok".
+
+`uptime` is the number of seconds since the server started. The host and port can be changed via `-healthcheck_host` and `-healthcheck_port`.
+
+The [docker image](https://hub.docker.com/r/shizunge/endlessh-go) includes a built-in `HEALTHCHECK` that runs every 30 seconds.
 
 ## Dashboard
 

--- a/endlessh_integration_test.go
+++ b/endlessh_integration_test.go
@@ -46,6 +46,7 @@ func TestEndlesshIntegration_MultiplePorts(t *testing.T) {
 	args := []string{"run", "main.go",
 		"-interval_ms=100",
 		"-max_clients=10",
+		"-healthcheck_port=0",
 		"-logtostderr",
 		"-v=1",
 	}
@@ -88,7 +89,7 @@ func TestEndlesshIntegration_MultiplePorts(t *testing.T) {
 
 func TestEndlesshIntegration_TarpitBehavior(t *testing.T) {
 	var stderr bytes.Buffer
-	cmd := exec.Command("go", "run", "main.go", "-port=0", "-interval_ms=5000", "-max_clients=10", "-logtostderr", "-v=1")
+	cmd := exec.Command("go", "run", "main.go", "-port=0", "-healthcheck_port=0", "-interval_ms=5000", "-max_clients=10", "-logtostderr", "-v=1")
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Failed to start server: %v", err)
@@ -144,7 +145,7 @@ func TestEndlesshIntegration_TarpitBehavior(t *testing.T) {
 func TestEndlesshIntegration_Concurrency(t *testing.T) {
 	maxClients := 5
 	var stderr bytes.Buffer
-	cmd := exec.Command("go", "run", "main.go", "-port=0", "-interval_ms=1000", fmt.Sprintf("-max_clients=%d", maxClients), "-logtostderr", "-v=1")
+	cmd := exec.Command("go", "run", "main.go", "-port=0", "-healthcheck_port=0", "-interval_ms=1000", fmt.Sprintf("-max_clients=%d", maxClients), "-logtostderr", "-v=1")
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
@@ -263,6 +264,7 @@ func TestEndlesshIntegration_PrometheusMetrics(t *testing.T) {
 	cmd := exec.Command(
 		"go", "run", "main.go",
 		"-port=0",
+		"-healthcheck_port=0",
 		"-enable_prometheus",
 		"-prometheus_port=0",
 		"-interval_ms=100",

--- a/endlessh_integration_test.go
+++ b/endlessh_integration_test.go
@@ -46,7 +46,6 @@ func TestEndlesshIntegration_MultiplePorts(t *testing.T) {
 	args := []string{"run", "main.go",
 		"-interval_ms=100",
 		"-max_clients=10",
-		"-healthcheck_port=0",
 		"-logtostderr",
 		"-v=1",
 	}
@@ -89,7 +88,7 @@ func TestEndlesshIntegration_MultiplePorts(t *testing.T) {
 
 func TestEndlesshIntegration_TarpitBehavior(t *testing.T) {
 	var stderr bytes.Buffer
-	cmd := exec.Command("go", "run", "main.go", "-port=0", "-healthcheck_port=0", "-interval_ms=5000", "-max_clients=10", "-logtostderr", "-v=1")
+	cmd := exec.Command("go", "run", "main.go", "-port=0", "-interval_ms=5000", "-max_clients=10", "-logtostderr", "-v=1")
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Failed to start server: %v", err)
@@ -145,7 +144,7 @@ func TestEndlesshIntegration_TarpitBehavior(t *testing.T) {
 func TestEndlesshIntegration_Concurrency(t *testing.T) {
 	maxClients := 5
 	var stderr bytes.Buffer
-	cmd := exec.Command("go", "run", "main.go", "-port=0", "-healthcheck_port=0", "-interval_ms=1000", fmt.Sprintf("-max_clients=%d", maxClients), "-logtostderr", "-v=1")
+	cmd := exec.Command("go", "run", "main.go", "-port=0", "-interval_ms=1000", fmt.Sprintf("-max_clients=%d", maxClients), "-logtostderr", "-v=1")
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
@@ -264,7 +263,6 @@ func TestEndlesshIntegration_PrometheusMetrics(t *testing.T) {
 	cmd := exec.Command(
 		"go", "run", "main.go",
 		"-port=0",
-		"-healthcheck_port=0",
 		"-enable_prometheus",
 		"-prometheus_port=0",
 		"-interval_ms=100",

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Paolo Asperti
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+package health
+
+import (
+	"net"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+const (
+	DefaultPort    = "51000"
+	DefaultTimeout = 3 * time.Second
+)
+
+func StartListener(port string) {
+	go func() {
+		l, err := net.Listen("tcp", "127.0.0.1:"+port)
+		if err != nil {
+			glog.Errorf("Error listening for healthcheck on 127.0.0.1:%v: %v", port, err)
+			os.Exit(1)
+		}
+		defer l.Close()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				glog.Errorf("Error accepting healthcheck connection: %v", err)
+				os.Exit(1)
+			}
+			conn.Close()
+		}
+	}()
+}
+
+func Probe(port string) bool {
+	timeout := DefaultTimeout
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, timeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/health/health.go
+++ b/health/health.go
@@ -17,7 +17,9 @@
 package health
 
 import (
+	"encoding/json"
 	"net"
+	"net/http"
 	"os"
 	"time"
 
@@ -27,36 +29,58 @@ import (
 const (
 	DefaultHost    = "127.0.0.1"
 	DefaultPort    = "51000"
+	DefaultPath    = "/health"
 	DefaultTimeout = 3 * time.Second
 )
 
+type response struct {
+	Status string  `json:"status"` // always "ok"
+	Uptime float64 `json:"uptime"` // in seconds
+}
+
+var startTime time.Time
+
 func StartListener(host, port string) {
-	addr := host + ":" + port
+	startTime = time.Now()
+	mux := http.NewServeMux()
+	mux.HandleFunc(DefaultPath, handleHealth)
+	addr := net.JoinHostPort(host, port)
 	go func() {
-		l, err := net.Listen("tcp", addr)
-		if err != nil {
+		glog.Infof("Starting healthcheck on http://%v%v", addr, DefaultPath)
+		if err := http.ListenAndServe(addr, mux); err != nil {
 			glog.Errorf("Error listening for healthcheck on %v: %v", addr, err)
 			os.Exit(1)
-		}
-		defer l.Close()
-		for {
-			conn, err := l.Accept()
-			if err != nil {
-				glog.Errorf("Error accepting healthcheck connection: %v", err)
-				os.Exit(1)
-			}
-			conn.Close()
 		}
 	}()
 }
 
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response{
+		Status: "ok",
+		Uptime: time.Since(startTime).Seconds(),
+	})
+}
+
 func Probe(host, port string) bool {
-	addr := host + ":" + port
-	timeout := DefaultTimeout
-	conn, err := net.DialTimeout("tcp", addr, timeout)
+	addr := net.JoinHostPort(host, port)
+	url := "http://" + addr + DefaultPath
+	client := &http.Client{Timeout: DefaultTimeout}
+	resp, err := client.Get(url)
 	if err != nil {
 		return false
 	}
-	conn.Close()
-	return true
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	var body response
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false
+	}
+	return body.Status == "ok"
 }

--- a/health/health.go
+++ b/health/health.go
@@ -25,15 +25,17 @@ import (
 )
 
 const (
+	DefaultHost    = "127.0.0.1"
 	DefaultPort    = "51000"
 	DefaultTimeout = 3 * time.Second
 )
 
-func StartListener(port string) {
+func StartListener(host, port string) {
+	addr := host + ":" + port
 	go func() {
-		l, err := net.Listen("tcp", "127.0.0.1:"+port)
+		l, err := net.Listen("tcp", addr)
 		if err != nil {
-			glog.Errorf("Error listening for healthcheck on 127.0.0.1:%v: %v", port, err)
+			glog.Errorf("Error listening for healthcheck on %v: %v", addr, err)
 			os.Exit(1)
 		}
 		defer l.Close()
@@ -48,9 +50,10 @@ func StartListener(port string) {
 	}()
 }
 
-func Probe(port string) bool {
+func Probe(host, port string) bool {
+	addr := host + ":" + port
 	timeout := DefaultTimeout
-	conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, timeout)
+	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
 		return false
 	}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"endlessh-go/client"
 	"endlessh-go/geoip"
+	"endlessh-go/health"
 	"endlessh-go/metrics"
 	"flag"
 	"fmt"
@@ -145,12 +146,21 @@ func main() {
 	maxMindDbFileName := flag.String("max_mind_db", "", "Path to the MaxMind DB file.")
 	proxyProtocolEnabled := flag.Bool("proxy_protocol_enabled", false, "Enable PROXY protocol support. This causes the server to expect PROXY protocol headers on incoming connections.")
 	proxyProtocolReadHeaderTimeout := flag.Int("proxy_protocol_read_header_timeout_ms", 200, "Timeout for reading the PROXY protocol header in milliseconds. If the connection does not send a valid PROXY protocol header in this time, the header is ignored.")
+	healthcheckPort := flag.String("healthcheck_port", health.DefaultPort, "TCP port for container healthcheck; accepts connectionsand closes without logging or metrics")
+	healthcheck := flag.Bool("healthcheck", false, "Dial healthcheck_port on 127.0.0.1 and exit 0 if reachable (for container healthcheck)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %v \n", os.Args[0])
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *healthcheck {
+		if !health.Probe(*healthcheckPort) {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 
 	if *prometheusEnabled {
 		if *connType == "tcp6" && *prometheusHost == "0.0.0.0" {
@@ -183,6 +193,7 @@ func main() {
 	if len(connPorts) == 0 {
 		connPorts = append(connPorts, defaultPort)
 	}
+	health.StartListener(*healthcheckPort)
 	for _, connPort := range connPorts {
 		startAccepting(*maxClients, *connType, *connHost, connPort, interval, clients, records, *proxyProtocolEnabled, *proxyProtocolReadHeaderTimeout)
 	}

--- a/main.go
+++ b/main.go
@@ -190,7 +190,15 @@ func main() {
 		})
 	clients := startSending(*maxClients, *bannerMaxLength, records)
 
-	// Start the healthcheck listener.
+	if *healthcheckPort == "0" || *healthcheckPort == "" {
+		l, err := net.Listen("tcp", *healthcheckHost+":0")
+		if err != nil {
+			glog.Fatalf("Failed to pick a free healthcheck port: %v", err)
+		}
+		actualPort := l.Addr().(*net.TCPAddr).Port
+		*healthcheckPort = strconv.Itoa(actualPort)
+		l.Close()
+	}
 	health.StartListener(*healthcheckHost, *healthcheckPort)
 
 	interval := time.Duration(*intervalMs) * time.Millisecond

--- a/main.go
+++ b/main.go
@@ -146,8 +146,9 @@ func main() {
 	maxMindDbFileName := flag.String("max_mind_db", "", "Path to the MaxMind DB file.")
 	proxyProtocolEnabled := flag.Bool("proxy_protocol_enabled", false, "Enable PROXY protocol support. This causes the server to expect PROXY protocol headers on incoming connections.")
 	proxyProtocolReadHeaderTimeout := flag.Int("proxy_protocol_read_header_timeout_ms", 200, "Timeout for reading the PROXY protocol header in milliseconds. If the connection does not send a valid PROXY protocol header in this time, the header is ignored.")
-	healthcheckPort := flag.String("healthcheck_port", health.DefaultPort, "TCP port for container healthcheck; accepts connectionsand closes without logging or metrics")
-	healthcheck := flag.Bool("healthcheck", false, "Dial healthcheck_port on 127.0.0.1 and exit 0 if reachable (for container healthcheck)")
+	healthcheckHost := flag.String("healthcheck_host", health.DefaultHost, "The address for container healthcheck")
+	healthcheckPort := flag.String("healthcheck_port", health.DefaultPort, "TCP port for container healthcheck; accepts connection and closes without logging or updating metrics")
+	healthcheck := flag.Bool("healthcheck", false, "Dial healthcheck_host:healthcheck_port and exit 0 if reachable (for container healthcheck)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %v \n", os.Args[0])
@@ -155,8 +156,12 @@ func main() {
 	}
 	flag.Parse()
 
+	if *connType == "tcp6" && *healthcheckHost == "0.0.0.0" {
+		*healthcheckHost = "[::]"
+	}
+
 	if *healthcheck {
-		if !health.Probe(*healthcheckPort) {
+		if !health.Probe(*healthcheckHost, *healthcheckPort) {
 			os.Exit(1)
 		}
 		os.Exit(0)
@@ -193,7 +198,7 @@ func main() {
 	if len(connPorts) == 0 {
 		connPorts = append(connPorts, defaultPort)
 	}
-	health.StartListener(*healthcheckPort)
+	health.StartListener(*healthcheckHost, *healthcheckPort)
 	for _, connPort := range connPorts {
 		startAccepting(*maxClients, *connType, *connHost, connPort, interval, clients, records, *proxyProtocolEnabled, *proxyProtocolReadHeaderTimeout)
 	}

--- a/main.go
+++ b/main.go
@@ -138,6 +138,7 @@ func main() {
 	connHost := flag.String("host", "0.0.0.0", "SSH listening address")
 	flag.Var(&connPorts, "port", fmt.Sprintf("SSH listening port. You may provide multiple -port flags to listen to multiple ports. (default %q)", defaultPort))
 	prometheusEnabled := flag.Bool("enable_prometheus", false, "Enable prometheus")
+	healthcheckEnabled := flag.Bool("enable_healthcheck", false, "Enable healthcheck")
 	prometheusHost := flag.String("prometheus_host", "0.0.0.0", "The address for prometheus")
 	prometheusPort := flag.String("prometheus_port", "2112", "The port for prometheus")
 	prometheusEntry := flag.String("prometheus_entry", "metrics", "Entry point for prometheus")
@@ -155,10 +156,6 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
-
-	if *connType == "tcp6" && *healthcheckHost == "0.0.0.0" {
-		*healthcheckHost = "[::]"
-	}
 
 	if *healthcheck {
 		if !health.Probe(*healthcheckHost, *healthcheckPort) {
@@ -190,16 +187,21 @@ func main() {
 		})
 	clients := startSending(*maxClients, *bannerMaxLength, records)
 
-	if *healthcheckPort == "0" || *healthcheckPort == "" {
-		l, err := net.Listen("tcp", *healthcheckHost+":0")
-		if err != nil {
-			glog.Fatalf("Failed to pick a free healthcheck port: %v", err)
+	if *healthcheckEnabled {
+		if *connType == "tcp6" && *healthcheckHost == "0.0.0.0" {
+			*healthcheckHost = "[::]"
 		}
-		actualPort := l.Addr().(*net.TCPAddr).Port
-		*healthcheckPort = strconv.Itoa(actualPort)
-		l.Close()
+		if *healthcheckPort == "0" || *healthcheckPort == "" {
+			l, err := net.Listen("tcp", *healthcheckHost+":0")
+			if err != nil {
+				glog.Fatalf("Failed to pick a free healthcheck port: %v", err)
+			}
+			actualPort := l.Addr().(*net.TCPAddr).Port
+			*healthcheckPort = strconv.Itoa(actualPort)
+			l.Close()
+		}
+		health.StartListener(*healthcheckHost, *healthcheckPort)
 	}
-	health.StartListener(*healthcheckHost, *healthcheckPort)
 
 	interval := time.Duration(*intervalMs) * time.Millisecond
 	// Listen for incoming connections.

--- a/main.go
+++ b/main.go
@@ -147,8 +147,8 @@ func main() {
 	proxyProtocolEnabled := flag.Bool("proxy_protocol_enabled", false, "Enable PROXY protocol support. This causes the server to expect PROXY protocol headers on incoming connections.")
 	proxyProtocolReadHeaderTimeout := flag.Int("proxy_protocol_read_header_timeout_ms", 200, "Timeout for reading the PROXY protocol header in milliseconds. If the connection does not send a valid PROXY protocol header in this time, the header is ignored.")
 	healthcheckHost := flag.String("healthcheck_host", health.DefaultHost, "The address for container healthcheck")
-	healthcheckPort := flag.String("healthcheck_port", health.DefaultPort, "TCP port for container healthcheck; accepts connection and closes without logging or updating metrics")
-	healthcheck := flag.Bool("healthcheck", false, "Dial healthcheck_host:healthcheck_port and exit 0 if reachable (for container healthcheck)")
+	healthcheckPort := flag.String("healthcheck_port", health.DefaultPort, "HTTP port for container healthcheck; serves JSON with status and uptime at /health")
+	healthcheck := flag.Bool("healthcheck", false, "GET healthcheck_host:healthcheck_port/health and exit 1 if status is not ok or timeout is exceeded (for container healthcheck)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %v \n", os.Args[0])

--- a/main.go
+++ b/main.go
@@ -190,6 +190,9 @@ func main() {
 		})
 	clients := startSending(*maxClients, *bannerMaxLength, records)
 
+	// Start the healthcheck listener.
+	health.StartListener(*healthcheckHost, *healthcheckPort)
+
 	interval := time.Duration(*intervalMs) * time.Millisecond
 	// Listen for incoming connections.
 	if *connType == "tcp6" && *connHost == "0.0.0.0" {
@@ -198,7 +201,6 @@ func main() {
 	if len(connPorts) == 0 {
 		connPorts = append(connPorts, defaultPort)
 	}
-	health.StartListener(*healthcheckHost, *healthcheckPort)
 	for _, connPort := range connPorts {
 		startAccepting(*maxClients, *connType, *connHost, connPort, interval, clients, records, *proxyProtocolEnabled, *proxyProtocolReadHeaderTimeout)
 	}


### PR DESCRIPTION
Added a healthcheck to the container, without adding extra binaries.

A tcp listener is started on `127.0.0.1` when program starts, with option to change the port. This listener just accept the connection and nothing else (it is enough to prove that the program is running). Nothing is logged, metrics are unaffected by this.

Container healthcheck is invoking the same binary with the `-healthcheck` argument, which tries the connection to the healthcheck port and exits immediatly with status code 0 if OK, 1 otherwise (in case of timeout or connection not established).

Container image size is practically the same.

Just the bare minimum :)